### PR TITLE
tableのエイリアス名を付ける場合はTableのコピーを行う

### DIFF
--- a/column.go
+++ b/column.go
@@ -95,6 +95,51 @@ func (c *baseColumn) SerializeSql(out *bytes.Buffer) error {
 	return c.SerializeSqlForColumnList(out)
 }
 
+func clone(c interface{}) (NonAliasColumn, error) {
+	switch c.(type) {
+	case *bytesColumn:
+		c := c.(*bytesColumn)
+		return BytesColumn(
+			c.name,
+			c.nullable,
+		), nil
+	case *stringColumn:
+		c := c.(*stringColumn)
+		return StrColumn(
+			c.name,
+			c.charset,
+			c.collation,
+			c.nullable,
+		), nil
+	case *dateTimeColumn:
+		c := c.(*dateTimeColumn)
+		return DateTimeColumn(
+			c.name,
+			c.nullable,
+		), nil
+	case *integerColumn:
+		c := c.(*integerColumn)
+		return IntColumn(
+			c.name,
+			c.nullable,
+		), nil
+	case *doubleColumn:
+		c := c.(*doubleColumn)
+		return DoubleColumn(
+			c.name,
+			c.nullable,
+		), nil
+	case *booleanColumn:
+		c := c.(*booleanColumn)
+		return BoolColumn(
+			c.name,
+			c.nullable,
+		), nil
+	default:
+		panic("not implemented type")
+	}
+}
+
 type bytesColumn struct {
 	baseColumn
 	isExpression

--- a/table_test.go
+++ b/table_test.go
@@ -207,3 +207,31 @@ func (s *TableSuite) TestNestedRightJoin(c *gc.C) {
 			"JOIN `db`.`table2` ON `table1`.`col3`=`table2`.`col3` "+
 			"RIGHT JOIN `db`.`table3` ON `table1`.`col1`=`table3`.`col1`")
 }
+
+func (s *TableSuite) TestAlias(c *gc.C) {
+	t2, err := table2.Alias("a1")
+	if err != nil {
+		c.Fatal("error occurred")
+	}
+
+	t3, err := table3.Alias("a2")
+	if err != nil {
+		c.Fatal("error occurred")
+	}
+
+	join1 := table1.InnerJoinOn(t2, Eq(table1Col3, t2.columns[0]))
+	join2 := join1.RightJoinOn(t3, Eq(table1Col1, t3.columns[0]))
+
+	buf := &bytes.Buffer{}
+
+	err = join2.SerializeSql("db", buf)
+	c.Assert(err, gc.IsNil)
+
+	sql := buf.String()
+	c.Assert(
+		sql,
+		gc.Equals,
+		"`db`.`table1` "+
+			"JOIN `db`.`table2` AS `a1` ON `table1`.`col3`=`a1`.`col3` "+
+			"RIGHT JOIN `db`.`table3` AS `a2` ON `table1`.`col1`=`a2`.`col1`")
+}


### PR DESCRIPTION
type Table structにAliasを追加した。
これにalias名を渡すと同名テーブルでのJOINができるようになる。